### PR TITLE
Added partial/filtered player search helper functions.

### DIFF
--- a/src/ServerScriptService/Server/SystemPackages/API.lua
+++ b/src/ServerScriptService/Server/SystemPackages/API.lua
@@ -49,6 +49,22 @@ function module.getPlayerWithName(Player: string)
 	end
 end
 
+function module.getPlayerWithNamePartial(Player: string)
+	for i,v in ipairs(Players:GetPlayers()) do
+		if v.Name:sub(1, #Player):lower() == Player:lower() then
+			return v;
+		end
+	end
+end
+
+function module.getPlayerWithFilter(filter: (Instance) -> boolean)
+	for i,v in ipairs(Players:GetPlayers()) do
+		if filter(v) == true then
+			return v;
+		end
+	end
+end
+
 function module.getUserIdWithName(Player: string)
 	local success, result = pcall(Players.GetUserIdFromNameAsync, Players, Player)
 	return result


### PR DESCRIPTION
Adds functionality to get players with only a partial name or a filter function. An example use case may be if command wants to grab a random player that meets a certain parameter in terms of their user data (ex. Get a random player that has at least 90 health, et cetera).