### PR TITLE
Refactored Server -> Client Bindable Usage

### DIFF
--- a/src/ServerScriptService/Server/Packages/Ban.lua
+++ b/src/ServerScriptService/Server/Packages/Ban.lua
@@ -11,15 +11,18 @@ module.Execute = function(Client, Type, Attachment)
 		local player = module.API.getUserIdWithName(Attachment)
 		local actualPlayer = module.API.getPlayerWithName(Attachment)
 		if typeof(player) == "number" and not module.API.checkAdmin(player) then
-			module.API.sendModalToPlayer(Client, "Reason?").Event:Connect(function(Input)
-				if Input ~= false then
-					local success, result = module.API.filterText(Client, Input)
-					success = pcall(dataStore.SetAsync, dataStore, player, {End = math.huge, Reason = result})
-					if actualPlayer and success then
-						actualPlayer:Kick("\nPermanently banned\nReason: " ..  result)
-					end
-				end
-			end)
+			local Input = module.API.sendModalToPlayer(Client, "Reason?").Event:Wait()
+			
+			if Input == false then
+				return
+			end
+
+			local success, result = module.API.filterText(Client, Input)
+			success = pcall(dataStore.SetAsync, dataStore, player, {End = math.huge, Reason = result})
+			
+			if actualPlayer and success then
+				actualPlayer:Kick("\nPermanently banned\nReason: " ..  result)
+			end
 		end
 	elseif Type == "firstrun" then
 		module.API.registerPlayerAddedEvent(function(Client)

--- a/src/ServerScriptService/Server/Packages/Chat.lua
+++ b/src/ServerScriptService/Server/Packages/Chat.lua
@@ -7,21 +7,24 @@ local module = {
 
 module.Execute = function(Client, Type, Attachment)			
 	if Type == "command" then
-		module.API.sendModalToPlayer(Client, "What's the message?").Event:Connect(function(Input)
-			if Input ~= false then
-				local Status
-				Status, Input = module.API.filterText(Client, Input)
-				if Status then
-					module.API.doThisToPlayers(Client, Attachment, function(Player)
-						if Player.Character then
-							Chat:Chat(Player.Character, Input)
-						end
-					end)
-				else
-					module.Remotes.Event:FireClient(Client, "newMessage", "", {From = "System", Content = "Your bubble chat request to \"" .. tostring(Attachment) .. "\" failed to filter, please retry later."})
+		local Input = module.API.sendModalToPlayer(Client, "What's the message?").Event:Wait()
+
+		if Input == false then
+			return
+		end
+
+		local Status
+		Status, Input = module.API.filterText(Client, Input)
+		
+		if Status then
+			module.API.doThisToPlayers(Client, Attachment, function(Player)
+				if Player.Character then
+					Chat:Chat(Player.Character, Input)
 				end
-			end
-		end)
+			end)
+		else
+			module.Remotes.Event:FireClient(Client, "newMessage", "", {From = "System", Content = "Your bubble chat request to \"" .. tostring(Attachment) .. "\" failed to filter, please retry later."})
+		end
 	end
 end
 

--- a/src/ServerScriptService/Server/Packages/Damage.lua
+++ b/src/ServerScriptService/Server/Packages/Damage.lua
@@ -6,14 +6,17 @@ local module = {
 
 module.Execute = function(Client, Type, Attachment)			
 	if Type == "command" then
-		module.API.sendModalToPlayer(Client).Event:Connect(function(Input)
-			if Input ~= false then
-				local char = module.API.getCharacter(module.API.getPlayerWithName(Attachment))
-				if char then
-					char.Humanoid:TakeDamage(tonumber(Input))
-				end
-			end
-		end)
+		local Input = module.API.sendModalToPlayer(Client).Event:Wait()
+		
+		if Input == false then
+			return
+		end
+
+		local char = module.API.getCharacter(module.API.getPlayerWithName(Attachment))
+
+		if char then
+			char.Humanoid:TakeDamage(tonumber(Input))
+		end
 	end
 end
 

--- a/src/ServerScriptService/Server/Packages/Health.lua
+++ b/src/ServerScriptService/Server/Packages/Health.lua
@@ -6,14 +6,17 @@ local module = {
 
 module.Execute = function(Client, Type, Attachment)			
 	if Type == "command" then
-		module.API.sendModalToPlayer(Client).Event:Connect(function(Input)
-			if Input ~= false then
-				local char = module.API.getCharacter(module.API.getPlayerWithName(Attachment))
-				if char then
-					char.Humanoid.Health = tonumber(Input)
-				end
-			end
-		end)
+		local Input = module.API.sendModalToPlayer(Client).Event:Wait()
+
+		if Input == false then
+			return
+		end
+
+		local char = module.API.getCharacter(module.API.getPlayerWithName(Attachment))
+		
+		if char then
+			char.Humanoid.Health = tonumber(Input)
+		end
 	end
 end
 

--- a/src/ServerScriptService/Server/Packages/Kick.lua
+++ b/src/ServerScriptService/Server/Packages/Kick.lua
@@ -8,14 +8,17 @@ module.Execute = function(Client, Type, Attachment)
 	if Type == "command" then
 		local player = module.API.getPlayerWithName(Attachment)
 		if player and not module.API.checkAdmin(player.UserId) then
-			module.API.sendModalToPlayer(Client).Event:Connect(function(Input)
-				if Input ~= false then
-					local success, result = module.API.filterText(Client, Input)
-					if success and result then
-						player:Kick(result)
-					end
-				end
-			end)
+			local Input = module.API.sendModalToPlayer(Client).Event:Wait()
+
+			if Input == false then
+				return
+			end
+
+			local success, result = module.API.filterText(Client, Input)
+			
+			if success and result then
+				player:Kick(result)
+			end
 		end
 	end
 end

--- a/src/ServerScriptService/Server/Packages/MaxHealth.lua
+++ b/src/ServerScriptService/Server/Packages/MaxHealth.lua
@@ -7,13 +7,15 @@ local module = {
 module.Execute = function(Client, Type, Attachment)			
 	if Type == "command" then
 		local char = module.API.getCharacter(module.API.getPlayerWithName(Attachment))
-		module.API.sendModalToPlayer(Client).Event:Connect(function(Input)
-			if Input ~= false then
-				if char then
-					char.Humanoid.MaxHealth = tonumber(Input)
-				end
-			end
-		end)
+		local Input = module.API.sendModalToPlayer(Client).Event:Wait()
+
+		if Input == false then
+			return
+		end
+
+		if char then
+			char.Humanoid.MaxHealth = tonumber(Input)
+		end
 	end
 end
 

--- a/src/ServerScriptService/Server/Packages/Message.lua
+++ b/src/ServerScriptService/Server/Packages/Message.lua
@@ -6,19 +6,22 @@ local module = {
 
 module.Execute = function(Client, Type, Attachment)			
 	if Type == "command" then
-		module.API.sendModalToPlayer(Client, "What's the message?").Event:Connect(function(Input)
-			if Input ~= false then
-				local Status
-				Status, Input = module.API.filterText(Client, Input)
-				if Status then
-					module.API.doThisToPlayers(Client, Attachment, function(Player)
-						module.Remotes.Event:FireClient(Player, "newMessage", "", {From = Client.Name, Content = Input})
-					end)
-				else
-					module.Remotes.Event:FireClient(Client, "newMessage", "", {From = "System", Content = "Your message to \"" .. tostring(Attachment) .. "\" failed to deliver, please retry later."})
-				end
-			end
-		end)
+		local Input = module.API.sendModalToPlayer(Client, "What's the message?").Event:Wait()
+		
+		if Input == false then
+			return
+		end
+
+		local Status
+		Status, Input = module.API.filterText(Client, Input)
+		
+		if Status then
+			module.API.doThisToPlayers(Client, Attachment, function(Player)
+				module.Remotes.Event:FireClient(Player, "newMessage", "", {From = Client.Name, Content = Input})
+			end)
+		else
+			module.Remotes.Event:FireClient(Client, "newMessage", "", {From = "System", Content = "Your message to \"" .. tostring(Attachment) .. "\" failed to deliver, please retry later."})
+		end
 	end
 end
 

--- a/src/ServerScriptService/Server/Packages/Power.lua
+++ b/src/ServerScriptService/Server/Packages/Power.lua
@@ -6,14 +6,17 @@ local module = {
 
 module.Execute = function(Client, Type, Attachment)			
 	if Type == "command" then
-		module.API.sendModalToPlayer(Client).Event:Connect(function(Input)
-			if Input ~= false then
-				local char = module.API.getCharacter(module.API.getPlayerWithName(Attachment))
-				if char then
-					char.Humanoid.JumpPower = tonumber(Input)
-				end
-			end
-		end)
+		local Input = module.API.sendModalToPlayer(Client).Event:Wait()
+		
+		if Input == false then
+			return
+		end
+
+		local char = module.API.getCharacter(module.API.getPlayerWithName(Attachment))
+		
+		if char then
+			char.Humanoid.JumpPower = tonumber(Input)
+		end
 	end
 end
 

--- a/src/ServerScriptService/Server/Packages/Shutdown.lua
+++ b/src/ServerScriptService/Server/Packages/Shutdown.lua
@@ -7,18 +7,21 @@ local module = {
 
 module.Execute = function(Client, Type, Attachment)			
 	if Type == "command" then
-		module.API.sendModalToPlayer(Client).Event:Connect(function(Input)
-			if Input ~= false then
-				local success, result = module.API.filterText(Client, Input)
-				if success and result then
-					module.Remotes.Event:FireAllClients("newMessage", "", {From = "System", Content = "This server will be shutting down in 5 seconds"})
-					wait(5)
-					for i,v in pairs(Players:GetPlayers()) do
-						v:Kick(result)
-					end
-				end
+		local Input = module.API.sendModalToPlayer(Client).Event:Wait()
+		
+		if Input == false then
+			return
+		end
+
+		local success, result = module.API.filterText(Client, Input)
+		
+		if success and result then
+			module.Remotes.Event:FireAllClients("newMessage", "", {From = "System", Content = "This server will be shutting down in 5 seconds"})
+			wait(5)
+			for i,v in pairs(Players:GetPlayers()) do
+				v:Kick(result)
 			end
-		end)
+		end
 	end
 end
 

--- a/src/ServerScriptService/Server/Packages/Speed.lua
+++ b/src/ServerScriptService/Server/Packages/Speed.lua
@@ -6,14 +6,17 @@ local module = {
 
 module.Execute = function(Client, Type, Attachment)			
 	if Type == "command" then
-		module.API.sendModalToPlayer(Client).Event:Connect(function(Input)
-			if Input ~= false then
-				local char = module.API.getCharacter(module.API.getPlayerWithName(Attachment))
-				if char then
-					char.Humanoid.WalkSpeed = tonumber(Input)
-				end
-			end
-		end)
+		local Input = module.API.sendModalToPlayer(Client).Event:Wait()
+		
+		if Input == false then
+			return
+		end
+
+		local char = module.API.getCharacter(module.API.getPlayerWithName(Attachment))
+		
+		if char then
+			char.Humanoid.WalkSpeed = tonumber(Input)
+		end
 	end
 end
 

--- a/src/ServerScriptService/Server/Packages/SystemMessage.lua
+++ b/src/ServerScriptService/Server/Packages/SystemMessage.lua
@@ -6,19 +6,22 @@ local module = {
 
 module.Execute = function(Client, Type, Attachment)			
 	if Type == "command" then
-		module.API.sendModalToPlayer(Client, "What's the message?").Event:Connect(function(Input)
-			if Input ~= false then
-				local Status
-				Status, Input = module.API.filterText(Client, Input)
-				if Status then
-					module.API.doThisToPlayers(Client, Attachment, function(Player)
-						module.Remotes.Event:FireClient(Player, "newMessage", "", {From = "System", Content = Input})
-					end)
-				else
-					module.Remotes.Event:FireClient(Client, "newMessage", "", {From = "System", Content = "Your message to \"" .. tostring(Attachment) .. "\" failed to deliver, please retry later."})
-				end
-			end
-		end)
+		local Input = module.API.sendModalToPlayer(Client, "What's the message?").Event:Wait()
+
+		if Input == false then
+			return
+		end
+
+		local Status
+		Status, Input = module.API.filterText(Client, Input)
+		
+		if Status then
+			module.API.doThisToPlayers(Client, Attachment, function(Player)
+				module.Remotes.Event:FireClient(Player, "newMessage", "", {From = "System", Content = Input})
+			end)
+		else
+			module.Remotes.Event:FireClient(Client, "newMessage", "", {From = "System", Content = "Your message to \"" .. tostring(Attachment) .. "\" failed to deliver, please retry later."})
+		end
 	end
 end
 

--- a/src/ServerScriptService/Server/Packages/Teleport.lua
+++ b/src/ServerScriptService/Server/Packages/Teleport.lua
@@ -8,18 +8,21 @@ module.Execute = function(Client, Type, Attachment)
 	if Type == "command" then
 		local char = module.API.getCharacter(module.API.getPlayerWithName(Attachment))
 		if char then
-			module.API.sendModalToPlayer(Client).Event:Connect(function(Input)
-				if Input ~= false then
-					local char1 = module.API.getCharacter(module.API.getPlayerWithName(Input))
-					if char1 then
-						local primaryPart = char.PrimaryPart
-						local primaryPart1 = char1.PrimaryPart
-						if primaryPart and primaryPart1 then
-							primaryPart.CFrame = primaryPart1.CFrame
-						end
-					end
+			local Input = module.API.sendModalToPlayer(Client).Event:Wait()
+			
+			if Input == false then
+				return
+			end
+			
+			local char1 = module.API.getCharacter(module.API.getPlayerWithName(Input))
+			
+			if char1 then
+				local primaryPart = char.PrimaryPart
+				local primaryPart1 = char1.PrimaryPart
+				if primaryPart and primaryPart1 then
+					primaryPart.CFrame = primaryPart1.CFrame
 				end
-			end)
+			end
 		end
 	end
 end

--- a/src/ServerScriptService/Server/Packages/Timeban.lua
+++ b/src/ServerScriptService/Server/Packages/Timeban.lua
@@ -11,19 +11,24 @@ module.Execute = function(Client, Type, Attachment)
 		local player = module.API.getUserIdWithName(Attachment)
 		local actualPlayer = module.API.getPlayerWithName(Attachment)
 		if typeof(player) == "number" and not module.API.checkAdmin(player) then
-			module.API.sendModalToPlayer(Client, "Reason?").Event:Connect(function(Input)
-				if Input ~= false then
-					module.API.sendModalToPlayer(Client, "How many hours?").Event:Connect(function(Input2)
-						if Input2 ~= false then
-							local success, result = module.API.filterText(Client, Input)
-							success = pcall(dataStore.SetAsync, dataStore, player, {End = os.time() + tonumber(Input2) * 60 * 60, Reason = result})
-							if actualPlayer and success then
-								Client:Kick("\nBanned\nReason: " .. result .. "\n\nCome back at " .. os.date("%d %b, %Y (%a) %X", tick() + tonumber(Input2) * 60 * 60))
-							end
-						end
-					end)
-				end
-			end)
+			local Input = module.API.sendModalToPlayer(Client, "Reason?").Event:Wait()
+			
+			if Input == false then
+				return
+			end
+			
+			local Input2 = module.API.sendModalToPlayer(Client, "How many hours?").Event:Wait()
+			
+			if Input2 == false then
+				return
+			end
+			
+			local success, result = module.API.filterText(Client, Input)
+			success = pcall(dataStore.SetAsync, dataStore, player, {End = os.time() + tonumber(Input2) * 60 * 60, Reason = result})
+			
+			if actualPlayer and success then
+				Client:Kick("\nBanned\nReason: " .. result .. "\n\nCome back at " .. os.date("%d %b, %Y (%a) %X", tick() + tonumber(Input2) * 60 * 60))
+			end
 		end
 	end
 end


### PR DESCRIPTION
Instead of using callbacks I have refactored the code to use [RBXScriptSignal#Wait](https://developer.roblox.com/en-us/api-reference/datatype/RBXScriptSignal) to [increase readability](https://medium.com/techfront/javascript-callback-hell-simply-explained-93c3cf4be884) in some cases. Because in these cases all code after is reliant on the event value, there is no functional need to separate it in another callback function.

(ps. in nearly all cases they are not nested multiple levels, however it is just to create a standard since there is no need, and to prevent multiple nested callbacks in the case that another input may be added to these in the future)