### PR TITLE
Fix Mute.lua

### DIFF
--- a/src/server/Packages/Builtin/Mute.lua
+++ b/src/server/Packages/Builtin/Mute.lua
@@ -9,7 +9,7 @@ module.Execute = function(Client, Type, Attachment)
 		local player = module.API.getPlayerWithName(Attachment)
 		if player then
             module.API.Players.hint(player, "System", "You have been muted by " .. Client.name)
-            module.Remotes.Event:FireClient(player, "setCoreGuiEnabled", {["Type"] = Enum.CoreGuiType.Chat, ["Status"] = false})
+            module.Remotes.Event:FireClient(player, "setCoreGuiEnabled", 'n/a', {["Type"] = Enum.CoreGuiType.Chat, ["Status"] = false})
 			return true
 		end
 		return false


### PR DESCRIPTION
setCoreGuiEnabled event was being fired without `Protocol` argument, changed to `'n/a'`

Fixed:
- Patch Mute Command